### PR TITLE
Improve error message on import/2 (#9663)

### DIFF
--- a/lib/elixir/src/elixir_import.erl
+++ b/lib/elixir/src/elixir_import.erl
@@ -18,6 +18,8 @@ import(Meta, Ref, Opts, E) ->
         {Added1, Funs} = import_functions(Meta, Ref, Opts, E),
         {Added2, Macs} = import_macros(false, Meta, Ref, Opts, E),
         {Funs, Macs, Added1 or Added2};
+      {only, Other} ->
+        elixir_errors:form_error(Meta, E, ?MODULE, {invalid_option, only, Other});
       false ->
         {Added1, Funs} = import_functions(Meta, Ref, Opts, E),
         {Added2, Macs} = import_macros(false, Meta, Ref, Opts, E),
@@ -77,7 +79,9 @@ calculate(Meta, Key, Opts, Old, File, Existing) ->
           case keyfind(Key, Old) of
             false -> remove_underscored(Existing()) -- Except;
             {Key, OldImports} -> OldImports -- Except
-          end
+          end;
+        {except, Other} ->
+          elixir_errors:form_error(Meta, File, ?MODULE, {invalid_option, except, Other})
       end
   end,
 
@@ -166,6 +170,11 @@ format_error({invalid_import, {Receiver, Name, Arity}}) ->
 format_error({invalid_option, Option}) ->
   Message = "invalid :~s option for import, expected a keyword list with integer values",
   io_lib:format(Message, [Option]);
+
+format_error({invalid_option, Option, Value}) ->
+  Message = "invalid :~s option for import, expected value to be an atom :functions, :macros"
+  ", or a list literal, got: ~s",
+  io_lib:format(Message, [Option, 'Elixir.Macro':to_string(Value)]);
 
 format_error({special_form_conflict, {Receiver, Name, Arity}}) ->
   io_lib:format("cannot import ~ts.~ts/~B because it conflicts with Elixir special forms",

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -872,6 +872,31 @@ defmodule Kernel.ErrorsTest do
                       '''
   end
 
+  test "ensure valid import :only option" do
+    assert_eval_raise CompileError,
+                      "nofile:3: invalid :only option for import, expected value to be an atom " <>
+                        ":functions, :macros, or a list literal, got: x",
+                      '''
+                      defmodule Kernel.ErrorsTest.Only do
+                        x = [flatten: 1]
+                        import List, only: x
+                      end
+                      '''
+  end
+
+  test "ensure valid import :except option" do
+    assert_eval_raise CompileError,
+                      "nofile:3: invalid :except option for import, expected value to be an atom " <>
+                        ":functions, :macros, or a list literal, got: " <>
+                        "Module.__get_attribute__(Kernel.ErrorsTest.Only, :x, 3)",
+                      '''
+                      defmodule Kernel.ErrorsTest.Only do
+                        @x [flatten: 1]
+                        import List, except: @x
+                      end
+                      '''
+  end
+
   test "unrequired macro" do
     assert_eval_raise CompileError,
                       "nofile:2: you must require Kernel.ErrorsTest before invoking " <>


### PR DESCRIPTION
Before:

    iex(1)> a = [flatten: 1]; import List, only: a
    ** (CaseClauseError) no case clause matching: {:only, {:a, [version: 0, line: 1], nil}}
        (elixir 1.10.0-dev) src/elixir_import.erl:10: :elixir_import.import/4

After:

    iex(1)> a = [flatten: 1]; import List, only: a
    ** (CompileError) iex:1: invalid :only option for import, expected value to be an atom :functions, :macros, or a list literal, got: a
        (elixir 1.10.0-dev) src/elixir_import.erl:22: :elixir_import.import/4