### PR TITLE
Ensure ERTS is not copied into release (#9752)

### DIFF
--- a/lib/mix/lib/mix/tasks/release.ex
+++ b/lib/mix/lib/mix/tasks/release.ex
@@ -1075,14 +1075,20 @@ defmodule Mix.Tasks.Release do
         [Path.join("lib", "#{name}-#{vsn}") | acc]
       end)
 
+    erts_dir =
+      case release.erts_source do
+        nil -> []
+        _ -> ["erts-#{release.erts_version}"]
+      end
+
     release_files =
       for basename <- File.ls!(Path.join(release.path, "releases")),
           not File.dir?(Path.join([release.path, "releases", basename])),
           do: Path.join("releases", basename)
 
     dirs =
-      ["bin", Path.join("releases", release.version), "erts-#{release.erts_version}"] ++
-        lib_dirs ++ release_files
+      ["bin", Path.join("releases", release.version)] ++
+        erts_dir ++ lib_dirs ++ release_files
 
     files =
       dirs


### PR DESCRIPTION
The default behaviour when starting a new mix project is to
`include_erts: true`.

If at some point you choose to `include_erts: false`, but have the ERTS
artifact hanging around from previous builds, it gets included in future
builds, therefore rendering `include_erts: false` broken when running on
systems that have built with `include_erts: true` for the same
environment.

`make_tar/1` currently always tries to include the ERTS artifact into
the archive, regardless of our `include_erts` configuration. this fails
in 1.9.4 if no previous artifact is present, and seems to be worked
around in the current implementation by simply ignoring source
directories that don't exist.

This adds a regression test for the behaviour by "simulating" an ERTS
leftover from a previous build.

This also adds logic to not try to include ERTS into archives in the
first place when our release is configured with `include_erts: false`.