### PR TITLE
Fix docs for compiler tracing events (#9760)

### DIFF
--- a/lib/elixir/lib/code.ex
+++ b/lib/elixir/lib/code.ex
@@ -75,8 +75,8 @@ defmodule Code do
       function or macro is referenced. `meta` is the call AST metadata, `module`
       is the invoked module, followed by the `name` and `arity`.
 
-    * `{:local_function, meta, module, name, arity}` and
-      `{:local_macro, meta, module, name, arity}` - traced whenever a local
+    * `{:local_function, meta, name, arity}` and
+      `{:local_macro, meta, name, arity}` - traced whenever a local
       function or macro is referenced. `meta` is the call AST metadata, `module`
       is the invoked module, followed by the `name` and `arity`.
 


### PR DESCRIPTION
The `local_function` event is a tuple with four elements, not five.