### PR TITLE
Revert "Warn on use of non-match argument to with/1 (#9784)"

### DIFF
--- a/lib/elixir/src/elixir_clauses.erl
+++ b/lib/elixir/src/elixir_clauses.erl
@@ -183,11 +183,7 @@ expand_with({'<-', Meta, [Left, Right]}, {E, _HasMatch}) ->
   {ERight, ER} = elixir_expand:expand(Right, E),
   {[ELeft], EL}  = head([Left], ER, E),
   {{'<-', Meta, [ELeft, ERight]}, {EL, true}};
-expand_with({'=', _Meta, _Args} = Expr, {E, HasMatch}) ->
-  {EExpr, EE} = elixir_expand:expand(Expr, E),
-  {EExpr, {EE, HasMatch}};
-expand_with({_, Meta, _Args} = Expr, {E, HasMatch}) ->
-  form_warn(Meta, ?key(E, file), ?MODULE, non_match_argument_in_with),
+expand_with(Expr, {E, HasMatch}) ->
   {EExpr, EE} = elixir_expand:expand(Expr, E),
   {EExpr, {EE, HasMatch}}.
 
@@ -405,9 +401,6 @@ format_error({try_with_only_else_clause, Origin}) ->
 
 format_error(unmatchable_else_in_with) ->
   "\"else\" clauses will never match because all patterns in \"with\" will always match";
-format_error(non_match_argument_in_with) ->
-  "\"with\" requires match expressions to be given either as \"left <- right\" or \"left = right\", "
-  "please assign your expression to underscore \"_\" if you want to simply execute some code and discard its value";
 
 format_error({zero_list_length_in_guard, ListArg}) ->
   Arg = 'Elixir.Macro':to_string(ListArg),

--- a/lib/elixir/test/elixir/kernel/warning_test.exs
+++ b/lib/elixir/test/elixir/kernel/warning_test.exs
@@ -1786,17 +1786,6 @@ defmodule Kernel.WarningTest do
              "extra parentheses on a remote function capture &System.pid()/0 have been deprecated. Please remove the parentheses: &System.pid/0"
   end
 
-  test "\"with\" warns when given an argument which is not a match" do
-    assert capture_err(fn ->
-             Code.eval_string("""
-             with fn -> true end do
-               :warn
-             end
-             """)
-           end) =~
-             "\"with\" requires match expressions to be given either as \"left <- right\" or \"left = right\""
-  end
-
   defp purge(list) when is_list(list) do
     Enum.each(list, &purge/1)
   end

--- a/lib/mix/lib/mix/dep/lock.ex
+++ b/lib/mix/lib/mix/dep/lock.ex
@@ -15,7 +15,7 @@ defmodule Mix.Dep.Lock do
     opts = [file: lockfile, warn_on_unnecessary_quotes: false]
 
     with {:ok, contents} <- File.read(lockfile),
-         _ = assert_no_merge_conflicts_in_lockfile(lockfile, contents),
+         assert_no_merge_conflicts_in_lockfile(lockfile, contents),
          {:ok, quoted} <- Code.string_to_quoted(contents, opts),
          {%{} = lock, _binding} <- Code.eval_quoted(quoted, [], opts) do
       lock


### PR DESCRIPTION
There are too many false negatives to make this warning worth it.

This reverts commit 35665e7aac23eb49a23f5bcdc8ecdbb1d2838d83.