### PR TITLE
Revert "Support `import Mod, only: :sigils` (#9822)"

### DIFF
--- a/lib/elixir/lib/kernel/special_forms.ex
+++ b/lib/elixir/lib/kernel/special_forms.ex
@@ -603,12 +603,11 @@ defmodule Kernel.SpecialForms do
 
       import List
 
-  A developer can filter to import just macros, functions, or sigils via
-  the `:only` option:
+  A developer can filter to import only macros or functions via
+  the only option:
 
       import List, only: :functions
       import List, only: :macros
-      import List, only: :sigils
 
   Alternatively, Elixir allows a developer to pass pairs of
   name/arities to `:only` or `:except` as a fine grained control

--- a/lib/elixir/test/elixir/kernel/errors_test.exs
+++ b/lib/elixir/test/elixir/kernel/errors_test.exs
@@ -861,7 +861,7 @@ defmodule Kernel.ErrorsTest do
   test "ensure valid import :only option" do
     assert_eval_raise CompileError,
                       "nofile:3: invalid :only option for import, expected value to be an atom " <>
-                        ":functions, :macros, :sigils, or a list literal, got: x",
+                        ":functions, :macros, or a list literal, got: x",
                       '''
                       defmodule Kernel.ErrorsTest.Only do
                         x = [flatten: 1]

--- a/lib/elixir/test/elixir/kernel/import_test.exs
+++ b/lib/elixir/test/elixir/kernel/import_test.exs
@@ -137,26 +137,6 @@ defmodule Kernel.ImportTest do
     import String
   end
 
-  defmodule Sigils do
-    # when imported it should cause conflict
-    def is_integer(_), do: false
-
-    def sigil_X(_, _), do: :x
-
-    defmacro sigil_Y(_, _), do: :y
-
-    def sigil__(_, _), do: :not_a_sigil
-  end
-
-  test "import only sigils" do
-    import Sigils, only: :sigils
-    assert is_integer(42)
-    assert ~X"" == :x
-    assert ~Y"" == :y
-    assert __ENV__.functions[Sigils] == [sigil_X: 2]
-    assert __ENV__.macros[Sigils] == [sigil_Y: 2]
-  end
-
   test "import many" do
     [import(List), import(String)]
     assert capitalize("foo") == "Foo"


### PR DESCRIPTION
It will be moved to the current multi-letter sigils PR.

This reverts commit 26adc8db3dddfb580f5c08a3d7468d3d3190f892.