### PR TITLE
Make EEx trim behaviour more consistent

### DIFF
--- a/lib/eex/lib/eex.ex
+++ b/lib/eex/lib/eex.ex
@@ -45,9 +45,8 @@ defmodule EEx do
     * `:indentation` - (since v1.11.0) an integer added to the column after every
       new line. Defaults to 0.
     * `:engine` - the EEx engine to be used for compilation.
-    * `:trim` - if true, trims whitespace left/right of quotation tags. If a
-      quotation tag appears on its own in a given line, line endings are also
-      removed. Defaults to false.
+    * `:trim` - if true, trims whitespace left/right of quotation tags up until
+      newlines. At least one newline is retained. Defaults to false.
 
   ## Engine
 

--- a/lib/eex/lib/eex/compiler.ex
+++ b/lib/eex/lib/eex/compiler.ex
@@ -46,7 +46,7 @@ defmodule EEx.Compiler do
     generate_buffer(rest, buffer, scope, state)
   end
 
-  defp generate_buffer([{:expr, line, column, mark, chars, _} | rest], buffer, scope, state) do
+  defp generate_buffer([{:expr, line, column, mark, chars} | rest], buffer, scope, state) do
     options = [file: state.file, line: line, column: column(column, mark)] ++ state.parser_options
     expr = Code.string_to_quoted!(chars, options)
     buffer = state.engine.handle_expr(buffer, IO.chardata_to_string(mark), expr)
@@ -54,7 +54,7 @@ defmodule EEx.Compiler do
   end
 
   defp generate_buffer(
-         [{:start_expr, start_line, start_column, mark, chars, _} | rest],
+         [{:start_expr, start_line, start_column, mark, chars} | rest],
          buffer,
          scope,
          state
@@ -80,7 +80,7 @@ defmodule EEx.Compiler do
   end
 
   defp generate_buffer(
-         [{:middle_expr, line, _column, '', chars, _} | rest],
+         [{:middle_expr, line, _column, '', chars} | rest],
          buffer,
          [current | scope],
          state
@@ -91,7 +91,7 @@ defmodule EEx.Compiler do
   end
 
   defp generate_buffer(
-         [{:middle_expr, line, column, modifier, chars, trimmed?} | t],
+         [{:middle_expr, line, column, modifier, chars} | t],
          buffer,
          [_ | _] = scope,
          state
@@ -101,12 +101,12 @@ defmodule EEx.Compiler do
         "please remove \"#{modifier}\" accordingly"
 
     :elixir_errors.erl_warn(line, state.file, message)
-    generate_buffer([{:middle_expr, line, column, '', chars, trimmed?} | t], buffer, scope, state)
+    generate_buffer([{:middle_expr, line, column, '', chars} | t], buffer, scope, state)
     # TODO: Make this an error on Elixir v2.0 since it accidentally worked previously.
     # raise EEx.SyntaxError, message: message, file: state.file, line: line
   end
 
-  defp generate_buffer([{:middle_expr, line, column, _, chars, _} | _], _buffer, [], state) do
+  defp generate_buffer([{:middle_expr, line, column, _, chars} | _], _buffer, [], state) do
     raise EEx.SyntaxError,
       message: "unexpected middle of expression <%#{chars}%>",
       file: state.file,
@@ -115,7 +115,7 @@ defmodule EEx.Compiler do
   end
 
   defp generate_buffer(
-         [{:end_expr, line, _column, '', chars, _} | rest],
+         [{:end_expr, line, _column, '', chars} | rest],
          buffer,
          [current | _],
          state
@@ -129,7 +129,7 @@ defmodule EEx.Compiler do
   end
 
   defp generate_buffer(
-         [{:end_expr, line, column, modifier, chars, trimmed?} | t],
+         [{:end_expr, line, column, modifier, chars} | t],
          buffer,
          [_ | _] = scope,
          state
@@ -139,12 +139,12 @@ defmodule EEx.Compiler do
         "expression \"<%#{modifier}#{chars}%>\", please remove \"#{modifier}\" accordingly"
 
     :elixir_errors.erl_warn(line, state.file, message)
-    generate_buffer([{:end_expr, line, column, '', chars, trimmed?} | t], buffer, scope, state)
+    generate_buffer([{:end_expr, line, column, '', chars} | t], buffer, scope, state)
     # TODO: Make this an error on Elixir v2.0 since it accidentally worked previously.
     # raise EEx.SyntaxError, message: message, file: state.file, line: line, column: column
   end
 
-  defp generate_buffer([{:end_expr, line, column, _, chars, _} | _], _buffer, [], state) do
+  defp generate_buffer([{:end_expr, line, column, _, chars} | _], _buffer, [], state) do
     raise EEx.SyntaxError,
       message: "unexpected end of expression <%#{chars}%>",
       file: state.file,
@@ -179,7 +179,7 @@ defmodule EEx.Compiler do
   # Look middle expressions that immediately follow a start_expr
 
   defp look_ahead_middle(
-         [{:text, text}, {:middle_expr, line, _column, _, chars, _} | rest] = tokens,
+         [{:text, text}, {:middle_expr, line, _column, _, chars} | rest] = tokens,
          start,
          contents
        ) do
@@ -190,7 +190,7 @@ defmodule EEx.Compiler do
     end
   end
 
-  defp look_ahead_middle([{:middle_expr, line, _column, _, chars, _} | rest], _start, contents) do
+  defp look_ahead_middle([{:middle_expr, line, _column, _, chars} | rest], _start, contents) do
     {contents ++ chars, line, rest}
   end
 

--- a/lib/eex/test/eex/tokenizer_test.exs
+++ b/lib/eex/test/eex/tokenizer_test.exs
@@ -16,27 +16,27 @@ defmodule EEx.TokenizerTest do
 
   test "strings with embedded code" do
     assert T.tokenize('foo <% bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '', ' bar ', false}, {:eof, 1, 14}]}
+             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '', ' bar '}, {:eof, 1, 14}]}
   end
 
   test "strings with embedded equals code" do
     assert T.tokenize('foo <%= bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '=', ' bar ', false}, {:eof, 1, 15}]}
+             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '=', ' bar '}, {:eof, 1, 15}]}
   end
 
   test "strings with embedded slash code" do
     assert T.tokenize('foo <%/ bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '/', ' bar ', false}, {:eof, 1, 15}]}
+             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '/', ' bar '}, {:eof, 1, 15}]}
   end
 
   test "strings with embedded pipe code" do
     assert T.tokenize('foo <%| bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '|', ' bar ', false}, {:eof, 1, 15}]}
+             {:ok, [{:text, 'foo '}, {:expr, 1, 5, '|', ' bar '}, {:eof, 1, 15}]}
   end
 
   test "strings with more than one line" do
     assert T.tokenize('foo\n<%= bar %>', 1, 1, @opts) ==
-             {:ok, [{:text, 'foo\n'}, {:expr, 2, 1, '=', ' bar ', false}, {:eof, 2, 11}]}
+             {:ok, [{:text, 'foo\n'}, {:expr, 2, 1, '=', ' bar '}, {:eof, 2, 11}]}
   end
 
   test "strings with more than one line and expression with more than one line" do
@@ -49,9 +49,9 @@ defmodule EEx.TokenizerTest do
 
     exprs = [
       {:text, 'foo '},
-      {:expr, 1, 5, '=', ' bar\n\nbaz ', false},
+      {:expr, 1, 5, '=', ' bar\n\nbaz '},
       {:text, '\n'},
-      {:expr, 4, 1, '', ' foo ', false},
+      {:expr, 4, 1, '', ' foo '},
       {:text, '\n'},
       {:eof, 5, 1}
     ]
@@ -72,9 +72,9 @@ defmodule EEx.TokenizerTest do
   test "quotation with interpolation" do
     exprs = [
       {:text, 'a <% b '},
-      {:expr, 1, 9, '=', ' c ', false},
+      {:expr, 1, 9, '=', ' c '},
       {:text, ' '},
-      {:expr, 1, 18, '=', ' d ', false},
+      {:expr, 1, 18, '=', ' d '},
       {:text, ' e %> f'},
       {:eof, 1, 33}
     ]
@@ -112,9 +112,9 @@ defmodule EEx.TokenizerTest do
   test "strings with embedded do end" do
     exprs = [
       {:text, 'foo '},
-      {:start_expr, 1, 5, '', ' if true do ', false},
+      {:start_expr, 1, 5, '', ' if true do '},
       {:text, 'bar'},
-      {:end_expr, 1, 24, '', ' end ', false},
+      {:end_expr, 1, 24, '', ' end '},
       {:eof, 1, 33}
     ]
 
@@ -124,12 +124,12 @@ defmodule EEx.TokenizerTest do
   test "strings with embedded -> end" do
     exprs = [
       {:text, 'foo '},
-      {:start_expr, 1, 5, '', ' cond do ', false},
-      {:middle_expr, 1, 18, '', ' false -> ', false},
+      {:start_expr, 1, 5, '', ' cond do '},
+      {:middle_expr, 1, 18, '', ' false -> '},
       {:text, 'bar'},
-      {:middle_expr, 1, 35, '', ' true -> ', false},
+      {:middle_expr, 1, 35, '', ' true -> '},
       {:text, 'baz'},
-      {:end_expr, 1, 51, '', ' end ', false},
+      {:end_expr, 1, 51, '', ' end '},
       {:eof, 1, 60}
     ]
 
@@ -139,11 +139,11 @@ defmodule EEx.TokenizerTest do
 
   test "strings with multiple callbacks" do
     exprs = [
-      {:start_expr, 1, 1, '=', ' a fn -> ', false},
+      {:start_expr, 1, 1, '=', ' a fn -> '},
       {:text, 'foo'},
-      {:middle_expr, 1, 18, '', ' end, fn -> ', false},
+      {:middle_expr, 1, 18, '', ' end, fn -> '},
       {:text, 'bar'},
-      {:end_expr, 1, 37, '', ' end ', false},
+      {:end_expr, 1, 37, '', ' end '},
       {:eof, 1, 46}
     ]
 
@@ -153,11 +153,11 @@ defmodule EEx.TokenizerTest do
 
   test "strings with callback followed by do block" do
     exprs = [
-      {:start_expr, 1, 1, '=', ' a fn -> ', false},
+      {:start_expr, 1, 1, '=', ' a fn -> '},
       {:text, 'foo'},
-      {:middle_expr, 1, 18, '', ' end do ', false},
+      {:middle_expr, 1, 18, '', ' end do '},
       {:text, 'bar'},
-      {:end_expr, 1, 33, '', ' end ', false},
+      {:end_expr, 1, 33, '', ' end '},
       {:eof, 1, 42}
     ]
 
@@ -167,11 +167,11 @@ defmodule EEx.TokenizerTest do
   test "strings with embedded keywords blocks" do
     exprs = [
       {:text, 'foo '},
-      {:start_expr, 1, 5, '', ' if true do ', false},
+      {:start_expr, 1, 5, '', ' if true do '},
       {:text, 'bar'},
-      {:middle_expr, 1, 24, '', ' else ', false},
+      {:middle_expr, 1, 24, '', ' else '},
       {:text, 'baz'},
-      {:end_expr, 1, 37, '', ' end ', false},
+      {:end_expr, 1, 37, '', ' end '},
       {:eof, 1, 46}
     ]
 
@@ -180,15 +180,15 @@ defmodule EEx.TokenizerTest do
   end
 
   test "trim mode" do
-    template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  '
+    template = '\t<%= if true do %> \n TRUE \n  <% else %>\n FALSE \n  <% end %>  \n\n  '
 
     exprs = [
-      {:start_expr, 1, 2, '=', ' if true do ', true},
-      {:text, ' TRUE \n'},
-      {:middle_expr, 3, 3, '', ' else ', true},
-      {:text, ' FALSE \n'},
-      {:end_expr, 5, 3, '', ' end ', true},
-      {:eof, 5, 12}
+      {:start_expr, 1, 2, '=', ' if true do '},
+      {:text, '\n TRUE \n'},
+      {:middle_expr, 3, 3, '', ' else '},
+      {:text, '\n FALSE \n'},
+      {:end_expr, 5, 3, '', ' end '},
+      {:eof, 7, 3}
     ]
 
     assert T.tokenize(template, 1, 1, %{@opts | trim: true}) == {:ok, exprs}
@@ -196,7 +196,7 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode with comment" do
     exprs = [
-      {:text, '123'},
+      {:text, '\n123'},
       {:eof, 2, 4}
     ]
 
@@ -205,9 +205,9 @@ defmodule EEx.TokenizerTest do
 
   test "trim mode with CRLF" do
     exprs = [
-      {:text, '0\r\n'},
-      {:expr, 2, 3, '=', ' 12 ', true},
-      {:text, '34'},
+      {:text, '0\n'},
+      {:expr, 2, 3, '=', ' 12 '},
+      {:text, '\n34'},
       {:eof, 3, 3}
     ]
 
@@ -217,7 +217,7 @@ defmodule EEx.TokenizerTest do
   test "trim mode set to false" do
     exprs = [
       {:text, ' '},
-      {:expr, 1, 2, '=', ' 12 ', false},
+      {:expr, 1, 2, '=', ' 12 '},
       {:text, ' \n'},
       {:eof, 2, 1}
     ]

--- a/lib/eex/test/eex_test.exs
+++ b/lib/eex/test/eex_test.exs
@@ -79,8 +79,24 @@ defmodule EExTest do
     end
 
     test "trim mode" do
+      string = "<%= 123 %> \n  \n  <%= 789 %>"
+      expected = "123\n789"
+      assert_eval(expected, string, [], trim: true)
+
       string = "<%= 123 %> \n456\n  <%= 789 %>"
-      expected = "123456\n789"
+      expected = "123\n456\n789"
+      assert_eval(expected, string, [], trim: true)
+
+      string = "<%= 123 %> \n  <%= 456 %>  \n  <%= 789 %>"
+      expected = "123\n456\n789"
+      assert_eval(expected, string, [], trim: true)
+
+      string = "\n  <%= 123 %> \n  <%= 456 %>  \n  <%= 789 %>  \n"
+      expected = "123\n456\n789"
+      assert_eval(expected, string, [], trim: true)
+
+      string = "\r\n  <%= 123 %> \r\n  <%= 456 %>  \r\n  <%= 789 %>  \r\n"
+      expected = "123\n456\n789"
       assert_eval(expected, string, [], trim: true)
     end
 
@@ -94,7 +110,7 @@ defmodule EExTest do
       <% end %>
       """
 
-      expected = "  that\n"
+      expected = "\n  that\n"
       assert_eval(expected, string, [], trim: true)
     end
 
@@ -106,7 +122,7 @@ defmodule EExTest do
       <%= "Fourth line" %>
       """
 
-      expected = "First lineSecond lineThird lineFourth line"
+      expected = "First line\nSecond line\nThird line\nFourth line"
       assert_eval(expected, string, [], trim: true)
     end
 
@@ -120,7 +136,7 @@ defmodule EExTest do
       <%end%>
       """
 
-      expected = "  that\n"
+      expected = "\n  that\n"
       assert_eval(expected, string, [], trim: true)
     end
 


### PR DESCRIPTION
The previous rules made it hard to understand how it really worked.

The new rules are simpler, as it trims all whitespace, including new
lines, both on left and right sides, leaving at least one newline.