### PR TITLE
Improve app name detection by the application tracer (#9900)

### DIFF
--- a/lib/mix/lib/mix/compilers/application_tracer.ex
+++ b/lib/mix/lib/mix/compilers/application_tracer.ex
@@ -57,7 +57,7 @@ defmodule Mix.Compilers.ApplicationTracer do
           # If the module belongs to this application (from another compiler), we skip it.
           # If the module is excluded, we skip it too.
           with path when is_list(path) <- :code.which(module),
-               [module_app, "ebin", _beam] <- path |> Path.split() |> Enum.take(-3),
+               {:ok, module_app} <- app(path),
                true <- module_app != app,
                false <- module in excludes or {module, function, arity} in excludes do
             env_mfa =
@@ -80,6 +80,15 @@ defmodule Mix.Compilers.ApplicationTracer do
     warnings
     |> Module.Checker.group_warnings()
     |> Module.Checker.emit_warnings()
+  end
+
+  # ../elixir/ebin/elixir.beam -> elixir
+  # ../ssl-9.6/ebin/ssl.beam -> ssl
+  defp app(path) do
+    case path |> Path.split() |> Enum.take(-3) do
+      [dir, "ebin", _beam] -> {:ok, dir |> String.split("-") |> hd()}
+      _ -> :error
+    end
   end
 
   def stop() do


### PR DESCRIPTION
OTP app directories contain version numbers and they are included in the name:

Before:

    warning: :ssl.versions/0 defined in application :ssl-9.6 is used by the current application but the current application does not directly depend on :ssl-9.6. To fix this, you must do one of:

      1. If :ssl-9.6 is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
    (...)

After:

    warning: :ssl.versions/0 defined in application :ssl is used by the current application but the current application does not directly depend on :ssl. To fix this, you must do one of:

      1. If :ssl is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
    (...)